### PR TITLE
Secret fix

### DIFF
--- a/.cloud/terraform/cloud-run.tf
+++ b/.cloud/terraform/cloud-run.tf
@@ -61,7 +61,7 @@ resource "google_cloud_run_service" "default" {
         }
         env {
           name  = "MESSAGEBIRD_ORIGINATOR"
-          value = local.messagebird.originator
+          value = local.messagebird.origin
         }
 
         # Concribo secrets

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Example configs are:
 ```json
 {
     "access_key": "key",
-    "originator": "Gumbo"
+    "origin": "Gumbo"
 }
 ```
 


### PR DESCRIPTION
Fixes `origin` and `originator` being used mixed through the docs